### PR TITLE
[Fix] Koa module declartion

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import { Utils } from './utils/utils';
 import { NetworkInterface } from './faces/network';
 import Logging from './utils/logging';
 
-declare module 'Koa' {
+declare module 'koa' {
   interface BaseContext {
     connection: Knex;
     network: NetworkInterface;


### PR DESCRIPTION
### Issue

On my Ubuntu OS the capital "K" is preventing the typescript transpiler from associating the module declaration to the `koa` package.

### Fix

Align casing with the imported package.