### PR TITLE
feat: blocks endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { txAnchorRoute, txRoute, txPostRoute } from './routes/transaction';
 import { Utils } from './utils/utils';
 import { NetworkInterface } from './faces/network';
 import Logging from './utils/logging';
+import { blocksRoute } from './routes/blocks';
 
 declare module 'koa' {
   interface BaseContext {
@@ -82,6 +83,8 @@ export default class ArLocal {
 
     this.router.get('/tx/:txid', txRoute);
     this.router.post('/tx', txPostRoute);
+
+    this.router.get('/block/hash/:indep_hash', blocksRoute);
 
     this.router.head(dataRouteRegex, dataHeadRoute);
     this.router.get(dataRouteRegex, dataRoute);

--- a/src/db/block.ts
+++ b/src/db/block.ts
@@ -12,6 +12,18 @@ export class BlockDB {
     return this.connection.select('*').from('blocks');
   }
 
+  async getByIndepHash(indepHash: string) {
+    const block = (
+      await this.connection.queryBuilder()
+        .select('*')
+        .from('blocks')
+        .where('id', '=', indepHash)
+        .limit(1)
+    )[0];
+
+    return block;
+  }
+
   async mine(height: number, previous: string, txs: string[]) {
     const id = Utils.randomID(64);
 

--- a/src/routes/blocks.ts
+++ b/src/routes/blocks.ts
@@ -1,0 +1,16 @@
+import { BlockDB } from '../db/block';
+import { Utils } from '../utils/utils';
+import Router from 'koa-router';
+
+let blockDB: BlockDB;
+
+export async function blocksRoute(ctx: Router.RouterContext) {
+  if (!blockDB) {
+    blockDB = new BlockDB(ctx.connection);
+  }
+
+  const indepHash = ctx.params.indep_hash;
+  const block = blockDB.getByIndepHash(indepHash);
+
+  ctx.body = block;
+}


### PR DESCRIPTION
An endpoint that tries to mimic the https://docs.arweave.org/developers/server/http-api#get-block-by-id behaviour.
An example use case is the "interactRead" from the SmartWeave SDK, which is using this endpoint to get the current block data (ie. its height, timestamp, etc.)