### PR TITLE
Fixing a compiler error when importing in Node

### DIFF
--- a/src/db/wallet.ts
+++ b/src/db/wallet.ts
@@ -1,4 +1,4 @@
-import { TransactionType } from 'faces/transaction';
+import { TransactionType } from '../faces/transaction';
 import { Knex } from 'knex';
 import { Utils } from '../utils/utils';
 export interface Wallet {


### PR DESCRIPTION
I noticed that when I tried to import arlocal in my Node project, `tsc` would return `error TS2307: Cannot find module 'faces/transaction' or its corresponding type declarations.` due to the path not being relative from the file but from the working directory. This is easily fixed with the change I added.