### PR TITLE
chore: bump sqlite3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "moment": "^2.29.1",
     "rfc4648": "^1.5.1",
     "smartweave": "^0.4.46",
-    "sqlite3": "^5.0.2",
+    "sqlite3": "^5.0.3",
     "tsc-watch": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to issue with sqlite3 on ARM Macbook (https://github.com/TryGhost/node-sqlite3/issues/1413) I propose to bump sqlite3 version.  

Edit: Currently the only solution is to install python2. It can be problematic as f.g. brew doesn't support installing python2 from the box. I locally tested that bumping sqlite3 makes dependency installation work without necessity to install python2. 

Edit2: Ok, so you have `^5.0.2` and this should cover this issue if anyone wants to install it from scratch or add as dependency.