### PR TITLE
:bug: fix: fix wrong winston to AR conversion on GQL

### DIFF
--- a/src/utils/ar.ts
+++ b/src/utils/ar.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js';
 
 export function winstonToAr(winstonString: string, { formatted = false, decimals = 12 } = {}) {
-  const num = stringToBigNum(winstonString, decimals).shiftedBy(-12);
+  const num = stringToBigNum(winstonString).shiftedBy(-12);
 
   return formatted ? num.toFormat(decimals) : num.toFixed(decimals);
 }
@@ -12,6 +12,6 @@ export function arToWinston(arString: string, { formatted = false } = {}) {
   return formatted ? num.toFormat() : num.toFixed(0);
 }
 
-export function stringToBigNum(stringValue: string, decimalPlaces: number = 12): BigNumber {
-  return new BigNumber(stringValue, decimalPlaces);
+export function stringToBigNum(stringValue: string): BigNumber {
+  return new BigNumber(stringValue); // second argument is base, defaulted to base 10
 }


### PR DESCRIPTION
The bug was caused due to the wrong value passed to the second expected argument of big-number constructor. It expected a number base and not decimal places.

![image](https://user-images.githubusercontent.com/65264054/182180695-ba560bd2-3d98-428e-9c82-d2535ee36e68.png)
