### PR TITLE
fix transaction offset,size type, number to string

### DIFF
--- a/src/routes/transaction.ts
+++ b/src/routes/transaction.ts
@@ -107,7 +107,7 @@ export async function txOffsetRoute(ctx: Router.RouterContext) {
     ctx.status = 200;
     ctx.type = 'text/plain'; // TODO: updated this in arweave gateway to app/json
 
-    ctx.body = { offset: +chunk.offset + +metadata.data_size - 1, size: metadata.data_size };
+    ctx.body = { offset: `${+chunk.offset + +metadata.data_size - 1}`, size: `${metadata.data_size}` };
   } catch (error) {
     console.error({ error });
   }


### PR DESCRIPTION
The api `/tx/{id}/offset` should return string type offset, size

ps. https://docs.arweave.org/developers/server/http-api