### PR TITLE
render reward from /price endpoint as string instead of number

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -131,7 +131,7 @@ export default class ArLocal {
     this.router.get('/tx_anchor', txAnchorRoute);
     this.router.get(
       '/price/:bytes/:addy?',
-      async (ctx) => (ctx.body = Math.round((+ctx.params.bytes / 1000) * 65595508)),
+      async (ctx) => (ctx.body = Math.round((+ctx.params.bytes / 1000) * 65595508).toString()),
     );
 
     // tx filter endpoint to restrict ans-104 txs


### PR DESCRIPTION
The official Arweave client used to automatically convert data from the `/price` endpoint to a string, until a recent commit: ArweaveTeam/arweave-js@533929de88516d3d0e590bd4545f08aaa61ea657. See https://github.com/ArweaveTeam/arweave-js/commit/533929de88516d3d0e590bd4545f08aaa61ea657#diff-1ebbcccfc095d19bae9d30a9c89603afbdfe85d3f6028364cc296c9ceb81ea28.

This makes it unable to use to post transactions with Arlocal as the latter renders the reward as a number in the `/price` endpoint. This PR fixes this issue by rendering the reward as a string instead.