### PR TITLE
fix: change data size to string and add empty data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arlocal",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "main": "./bin/app.js",
   "repository": "https://github.com/textury/arlocal.git",
   "author": "Cedrik <cedrik.git@tryninja.io>",

--- a/src/db/transaction.ts
+++ b/src/db/transaction.ts
@@ -104,11 +104,15 @@ export class TransactionDB {
     const tx = (
       await this.connection.queryBuilder().select('*').from('transactions').where('id', '=', txId).limit(1)
     )[0];
-
     try {
       tx.tags = JSON.parse(tx.tags);
+      if (tx.data_size) {
+        tx.data_size = tx.data_size.toString();
+      }
+      if (!tx.data) {
+        tx.data = "";
+      }
     } catch (e) {}
-
     return tx;
   }
 

--- a/src/routes/transaction.ts
+++ b/src/routes/transaction.ts
@@ -142,7 +142,6 @@ export async function txPostRoute(ctx: Router.RouterContext) {
     for (const tag of data.tags) {
       const name = Utils.atob(tag.name);
       const value = Utils.atob(tag.value);
-
       if (name === 'Bundle-Format') bundleFormat = value;
       if (name === 'Bundle-Version') bundleVersion = value;
     }


### PR DESCRIPTION
Hi, I am building the db3 network and using the arlocal as a local test environment. The arlocal does a lot of help for me but there are some compatibility problems that I am trying to fix

1. the `data_size` should return a string type but an integer
2. the `data` field must be included in the result 