### PR TITLE
Fix unbundling first item id in tx post route

### DIFF
--- a/src/routes/transaction.ts
+++ b/src/routes/transaction.ts
@@ -165,7 +165,7 @@ export async function txPostRoute(ctx: Router.RouterContext) {
             request: {
               ...ctx.request,
               body: {
-                id: bundle.getIdBy(i),
+                id: bundle.get(i).id,
                 bundledIn: data.id,
                 ...item.toJSON(),
               },


### PR DESCRIPTION
Seems to be a bug in arlocal the first item when using `getIdBy` is all As