### PR TITLE
Add falsy checks on `block?.min` and `block?.max` within GraphQL resolver

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -62,8 +62,8 @@ export const resolvers = {
         blocks: true,
         since: timestamp,
         select: fieldMap,
-        minHeight: queryParams.block?.min,
-        maxHeight: queryParams.block?.max,
+        minHeight: queryParams.block?.min || undefined,
+        maxHeight: queryParams.block?.max || undefined,
         sortOrder: queryParams.sort,
       };
 


### PR DESCRIPTION
Following my discussion with @ppedziwiatr within the issues #152 and https://github.com/warp-contracts/warp/issues/494 I have decided to revert two of the removed falsy checks (change was made here https://github.com/textury/arlocal/compare/v1.1.62...v1.1.63).

Please see the discussion within the issue for details.