### PR TITLE
chore(docker): update docker base image to node20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:16-alpine as build
+FROM node:20-alpine as build
 
 WORKDIR /app
 COPY . .
 RUN apk add git
 RUN yarn
 
-FROM node:16-alpine 
+FROM node:20-alpine 
 USER node
 WORKDIR /arlocal
 


### PR DESCRIPTION
16 is no longer maintained, 18 is in maintenance until Oct 2024.

https://endoflife.date/nodejs