### PR TITLE
Fix data_size returned as number instead of string when data_size = 0

### DIFF
--- a/src/db/transaction.ts
+++ b/src/db/transaction.ts
@@ -106,7 +106,7 @@ export class TransactionDB {
     )[0];
     try {
       tx.tags = JSON.parse(tx.tags);
-      if (tx.data_size) {
+      if (tx.data_size !== undefined) {
         tx.data_size = tx.data_size.toString();
       }
       if (!tx.data) {


### PR DESCRIPTION
`getById` returns number instead of string as when data_size is 0.
This breaks some libraries that expect data_size to be a string.